### PR TITLE
[feat] レコードを一括取得する処理の追加

### DIFF
--- a/src/infra/notion/repositories/getDatabaseRecords.ts
+++ b/src/infra/notion/repositories/getDatabaseRecords.ts
@@ -1,11 +1,11 @@
 import { notion } from "@/libs/notion/utils/client";
-import { getDatabaseRecordsResponse } from "../entities/record";
 
-const getDatabaseRecords = async (): Promise<getDatabaseRecordsResponse> => {
-  return await notion.dataSources.query({
+// TODO:型定義がSDKと合っていない問題
+const getDatabaseRecords = async () => {
+  const response = await notion.dataSources.query({
     data_source_id: process.env.DATA_SOURCE_ID!,
   });
+  return response;
 };
 
 export default getDatabaseRecords;
-import type { QueryDataSourceResponse } from "@notionhq/client/build/src/api-endpoints";


### PR DESCRIPTION
## notionAPIの概要
- `2025-09-03`以降からDBの情報を取得するエンドポイントと、レコード（DBの中身）を取得するエンドポイントが切り分けられた
- レコードを取得するには`data_source_id`がエンドポイント

## PRの概要
- `getDatabaseRecords`の作成
- `getDatabaseInfo`では、DBの全体の取得、`getDatabaseRecords`ではレコードの取得
- 取得されるデータは`notion-SDK-javascript`の`QueryDataSourceResponse`とほぼ一致しているが、`request_id`が抜けている
- 取得データが煩雑なので、`toRecord.ts`で必要なデータのみに変換する処理を行う
- 作業時間を`workTime.ts`で`start`と`end`から算出

## notion
あとでかく
