### PR TITLE
feat: カレンダーページ新規作成

### DIFF
--- a/src/app/Calendar/page.tsx
+++ b/src/app/Calendar/page.tsx
@@ -1,3 +1,4 @@
+import { getCurrent } from "@/commons/date/utils/getCurrent";
 import CalendarPageMain from "@/features/calendarPage/components/CalendarPageMain/CalendarPageMain";
 import toRecord from "@/features/notion/utils/toRecord";
 import getDBRecords from "@/infra/notion/repositories/getDBRecords";
@@ -11,17 +12,17 @@ type Props = {
 
 const CalendarPage = async (props: Props) => {
   const searchParams = await props.searchParams;
+  const today = getCurrent("YYYY-MM-DD");
 
-  const filter =
-    searchParams?.s && searchParams?.e
-      ? {
-          property: "workTime",
-          date: {
-            on_or_after: searchParams.s,
-            on_or_before: searchParams.e,
-          },
-        }
-      : undefined;
+  const start = searchParams?.s ?? today;
+  const end = searchParams?.e ?? today;
+
+  const filter = {
+    and: [
+      { property: "workTime", date: { on_or_after: start } },
+      { property: "workTime", date: { on_or_before: end } },
+    ],
+  };
 
   const allRecords = await getDBRecords(filter);
   const events = allRecords.results.map((record) => toRecord(record));

--- a/src/app/Calendar/page.tsx
+++ b/src/app/Calendar/page.tsx
@@ -1,0 +1,32 @@
+import CalendarPageMain from "@/features/calendarPage/components/CalendarPageMain/CalendarPageMain";
+import toRecord from "@/features/notion/utils/toRecord";
+import getDBRecords from "@/infra/notion/repositories/getDBRecords";
+
+type Props = {
+  searchParams?: {
+    s?: string | undefined;
+    e?: string | undefined;
+  };
+};
+
+const CalendarPage = async (props: Props) => {
+  const searchParams = await props.searchParams;
+
+  const filter =
+    searchParams?.s && searchParams?.e
+      ? {
+          property: "workTime",
+          date: {
+            on_or_after: searchParams.s,
+            on_or_before: searchParams.e,
+          },
+        }
+      : undefined;
+
+  const allRecords = await getDBRecords(filter);
+  const events = allRecords.results.map((record) => toRecord(record));
+
+  return <CalendarPageMain events={events} />;
+};
+
+export default CalendarPage;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,15 +3,7 @@ import toRecord from "@/features/notion/utils/toRecord";
 import getDBRecords from "@/infra/notion/repositories/getDBRecords";
 import getDBSchema from "@/infra/notion/repositories/getDBSchema";
 
-// type Props = {
-//   searchParams: { [key: string]: string | string[] | undefined };
-// };
-
 const Home = async () => {
-  // const startDate = props.searchParams.s;
-  // const endDate = props.searchParams.e;
-  // console.log(startDate, endDate);
-
   const filter = {
     property: "workTime",
     date: {

--- a/src/commons/calendar/components/Calendar/Calendar.stories.tsx
+++ b/src/commons/calendar/components/Calendar/Calendar.stories.tsx
@@ -15,6 +15,12 @@ const meta = {
   component: DayCalendar,
   parameters: {
     layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: "/",
+      },
+    },
   },
   decorators: [WithFormProvider],
 } satisfies Meta<typeof DayCalendar>;
@@ -26,6 +32,7 @@ export const Default: Story = {};
 
 export const WithEvents: Story = {
   args: {
+    initialDate: "2026-04-11",
     events: [
       {
         title: "朝会",
@@ -53,6 +60,7 @@ export const WithEvents: Story = {
 
 export const ShortEvents: Story = {
   args: {
+    initialDate: "2026-04-11",
     events: [
       {
         title: "短いミーティング",

--- a/src/commons/calendar/components/Calendar/Calendar.tsx
+++ b/src/commons/calendar/components/Calendar/Calendar.tsx
@@ -30,8 +30,8 @@ const Calendar = ({ events, header }: Props) => {
 
   const handleDatesSet = (dateInfo: DatesSetArg) => {
     const params = new URLSearchParams({
-      s: dateInfo.startStr,
-      e: dateInfo.endStr,
+      s: dateInfo.startStr.split("T")[0],
+      e: dateInfo.endStr.split("T")[0],
     });
     router.push(`?${params.toString()}`, { scroll: false });
   };
@@ -51,7 +51,9 @@ const Calendar = ({ events, header }: Props) => {
         headerToolbar={{
           left: "",
           center: "",
-          right: header ? "dayGridMonth,timeGridWeek,timeGridDay,prev,today,next" : "",
+          right: header
+            ? "dayGridMonth,timeGridWeek,timeGridDay,prev,today,next"
+            : "",
         }}
         contentHeight="auto"
         slotDuration="00:30:00"

--- a/src/commons/calendar/components/Calendar/Calendar.tsx
+++ b/src/commons/calendar/components/Calendar/Calendar.tsx
@@ -15,9 +15,10 @@ import { useRouter } from "next/navigation";
 type Props = {
   events?: NotionEvent[];
   header?: boolean;
+  initialDate?: string;
 };
 
-const Calendar = ({ events, header }: Props) => {
+const Calendar = ({ events, header, initialDate }: Props) => {
   const router = useRouter();
   const [isOpenModal, setIsOpenModal] = useState(false);
   const { setValue } = useFormContext();
@@ -41,6 +42,7 @@ const Calendar = ({ events, header }: Props) => {
       <FullCalendar
         plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
         initialView="timeGridDay"
+        initialDate={initialDate}
         datesSet={handleDatesSet}
         events={events}
         eventMinHeight={15}

--- a/src/commons/layout/components/BottomBar/BottomBar.tsx
+++ b/src/commons/layout/components/BottomBar/BottomBar.tsx
@@ -6,13 +6,13 @@ const text = "text-[13px] text-foreground italic font-semibold font-dm-sans";
 const BottomBar = () => {
   return (
     <div className="gap-8 flex bg-[#ffffff0a] rounded-[40px] py-3 px-7 w-fit border-[#FFFFFF25] border">
-      <Link href="./">
+      <Link href="/">
         <span className={text}>Todo</span>
       </Link>
-      <Link href="./">
+      <Link href="/Calendar">
         <span className={text}>Calendar</span>
       </Link>
-      <Link href="./">
+      <Link href="/Board">
         <span className={text}>Board</span>
       </Link>
     </div>

--- a/src/features/calendarPage/components/CalendarPageMain/CalendarPageMain.tsx
+++ b/src/features/calendarPage/components/CalendarPageMain/CalendarPageMain.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Calendar from "@/commons/calendar/components/Calendar/Calendar";
+import { NotionEvent } from "@/commons/calendar/type/notionEvent";
+import { addData } from "@/commons/modal/utils/addData";
+import SideBar from "@/features/home/components/SideBar/SideBar";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { FormProvider, useForm } from "react-hook-form";
+import { z } from "zod";
+
+type Props = {
+  events: NotionEvent[];
+};
+
+const formSchema = z.object({
+  start: z.string().min(1, "開始日時を入力してください"),
+  end: z.string().min(1, "終了日時を入力してください"),
+  label: z.string().optional(),
+  title: z.string().optional(),
+});
+type DataForm = z.infer<typeof formSchema>;
+
+const CalendarPageMain = ({ events }: Props) => {
+  const methods = useForm<DataForm>({
+    resolver: zodResolver(formSchema),
+    mode: "onChange",
+  });
+
+  const onSubmit = async (data: DataForm) => {
+    try {
+      const properties = {
+        title: { title: [{ text: { content: data.title ?? "" } }] },
+        workTime: {
+          date: {
+            start: data.start,
+            end: data.end,
+          },
+        },
+        ...(data.label && { select: { select: { name: data.label } } }),
+      };
+      await addData(properties);
+      methods.reset();
+    } catch (error) {
+      console.error(error); // TODO:errorハンドリングを考える
+    }
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(onSubmit)}>
+        <div className="flex flex-row bg-[#1A1A1A] h-screen">
+          <div className="shrink-0 my-auto">
+            <SideBar today={null} />
+          </div>
+          <div className="mx-16 mt-10">
+            <Calendar events={events} header />
+          </div>
+        </div>
+      </form>
+    </FormProvider>
+  );
+};
+
+export default CalendarPageMain;

--- a/src/features/home/components/HomePageMain/HomePageMain.tsx
+++ b/src/features/home/components/HomePageMain/HomePageMain.tsx
@@ -64,11 +64,11 @@ const HomePageMain = ({ labels, events }: Props) => {
               <BottomBar />
             </div>
           </div>
-          <div className="bg-[#1A1A1A]">
-            <Calendar events={events} />
-          </div>
         </form>
       </FormProvider>
+      <div className="bg-[#1A1A1A]">
+        <Calendar events={events} />
+      </div>
     </>
   );
 };

--- a/src/features/home/components/HomePageMain/HomePageMain.tsx
+++ b/src/features/home/components/HomePageMain/HomePageMain.tsx
@@ -7,8 +7,8 @@ import WorkCard from "@/commons/workCard/components/WorkCard";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import Calendar from "@/features/Calendar/components/Calendar/Calendar";
-import { NotionEvent } from "@/features/Calendar/type/notionEvent";
+import Calendar from "@/commons/calendar/components/Calendar/Calendar";
+import { NotionEvent } from "@/commons/calendar/type/notionEvent";
 
 type Props = {
   labels: string[];


### PR DESCRIPTION
## Summary
- `/Calendar` ページを新規作成
- `CalendarPageMain` コンポーネントを作成
- URLクエリ（`?s=`/`?e=`）で表示期間を指定できる（未指定時は今日）
- BottomBarの遷移先にカレンダーページを設定

## Dependencies
- feat/calendar-filter に依存（スタックPR）

## Test plan
- [ ] `/Calendar` にアクセスしてカレンダーが表示されること
- [ ] `?s=2026-05-01&e=2026-05-07` のようなクエリで期間を絞り込めること
- [ ] BottomBarからカレンダーページに遷移できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)