### PR TITLE
[fix] submitボタンの判定がテキストのみであったため、ボタン全体に修正

### DIFF
--- a/src/commons/modal/components/SubmitModal/SubmitModal.tsx
+++ b/src/commons/modal/components/SubmitModal/SubmitModal.tsx
@@ -48,19 +48,20 @@ const SubmitModal = ({ isOpenModal, setIsOpenModal }: Props) => {
             </div>
             <CommonSeparator />
             <div className="pt-4 px-5 pb-5 flex gap-3 justify-between">
-              <div className="bg-accent-lime rounded-xl py-3.5 flex w-full">
+              <button
+                type="submit"
+                className="bg-accent-lime rounded-xl py-3.5 flex w-full cursor-pointer"
+              >
                 <div className="m-auto flex gap-3">
                   <Plain
                     className="size-4.5 text-foreground-dark"
                     alt="submit"
                   />
-                  <input
-                    type="submit"
-                    value="これでOK！"
-                    className="text-foreground-dark text-[14px] font-bold cursor-pointer"
-                  />
+                  <span className="text-foreground-dark text-[14px] font-bold">
+                    これでOK！
+                  </span>
                 </div>
-              </div>
+              </button>
               <div className="bg-[#2A1515] rounded-xl px-4.5 py-3.5 shrink-0">
                 <button
                   type="button"


### PR DESCRIPTION
## 概要
これの「これでOK！」の部分しか送信の判定が入っていなかったため、ボタン全体に広げる
<img width="534" height="125" alt="image" src="https://github.com/user-attachments/assets/449b90e8-67a4-44ec-8f4f-f324138c9be6" />
